### PR TITLE
Make functions directory relative.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 # Location of dist functions
 [build]
-  functions = "/functions" # Where do built functions live
+  functions = "./functions" # Where do built functions live
   command = "npm run build" # What command to run to build 
   publish = "web" # Where does dist code live

--- a/package-lock.json
+++ b/package-lock.json
@@ -4817,6 +4817,14 @@
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -9309,7 +9317,6 @@
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -16134,8 +16141,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass-graph": {
       "version": "2.2.4",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
+    "encoding": "^0.1.12",
     "flickity": "^2.1.2",
     "isotope-layout": "^3.0.6",
     "jquery": "^3.3.1",


### PR DESCRIPTION
Netlify uses

```
const source = path.resolve(process.cwd(), sourceArg)
```

to identify the source directory of the build functions. The previous 'functions' config value was not a relative path but a absolute path e.g. '/function' (absolute) to './function' (relative).

The last successful deploy was on [Mar 1 at 1:43 PM](https://app.netlify.com/sites/nuccobrain-staging/deploys/5c793708b583ef000893afc2) and the logs make no reference of 'Zipping functions from ...' which is referenced in the failing builds. Since that deploy [this](https://github.com/netlify/zip-it-and-ship-it) repo has been created which seems like a new tool netlify use internally to zip up the function artifacts and ship them off to aws lambda.

They did indeed just start using it and I can see that there is a difference in how they resolve the paths in both programs. netlif-lambda uses:

```
path.join(process.cwd(), functionsDir)
```

zip-it-and-ship-it uses

```
path.resolve(process.cwd(), sourceDir)
```

The difference is, the first simply concatenates them together and the second looks to see if the folder actually exists on the machine. This is a problem for us as it resolves paths properly (instead of just naively mashing them together) since our path is absolute (it starts with a slash). This means that `path.resolve` will start looking from the root of the machine.

This seems like a vulnerability actually, I will let netlify know.